### PR TITLE
Make blocksize a local variable

### DIFF
--- a/src/frag_find.cpp
+++ b/src/frag_find.cpp
@@ -59,7 +59,6 @@ string _e = string("");
 void *initial_break = 0;
 
 blockfile imagefile;			// the file we are reading
-//SHOULD BE LOCAL VAR uint32_t blocksize = DEFAULT_BLOCKSIZE;
 bool use_prefilter = 0;
 int opt_raw = 0;
 
@@ -511,6 +510,7 @@ int main(int argc,char **argv)
     class xml *x = 0;
     string command_line;
     uint32_t blocksize = DEFAULT_BLOCKSIZE;
+    string opt_md5;
 
     /* Make a copy of the command line */
     for(int i=0;i<argc;i++){
@@ -528,7 +528,7 @@ int main(int argc,char **argv)
 	case 'b': blocksize = atoi(optarg); break;
 	case 'S': opt_stats++;break;
 	case 'M': opt_M     = atoi(optarg); break;
-	case 'm': masters.read_md5deep(optarg,blocksize); break;//TODO: properly get blocksize
+	case 'm': opt_md5 = optarg; break;
 	case 'X':
 	    switch(atoi(optarg)){
 	    case 1: use_bloom = 0;break;
@@ -551,6 +551,7 @@ int main(int argc,char **argv)
 	fprintf(stderr,"M must be between 5 and 32.\n");
 	exit(1);
     }
+    if (!opt_md5.empty()) masters.read_md5deep(opt_md5.c_str(),blocksize);
 
     argc -= optind; 
     argv += optind;

--- a/src/frag_find.cpp
+++ b/src/frag_find.cpp
@@ -59,7 +59,7 @@ string _e = string("");
 void *initial_break = 0;
 
 blockfile imagefile;			// the file we are reading
-uint32_t blocksize = DEFAULT_BLOCKSIZE;
+//SHOULD BE LOCAL VAR uint32_t blocksize = DEFAULT_BLOCKSIZE;
 bool use_prefilter = 0;
 int opt_raw = 0;
 
@@ -249,11 +249,11 @@ public:;
     md5map_t md5map;
     filemap_t filemap;
     void add_block_hash(uint32_t blocknumber,const md5_t &md5,NSRLBloom &b);
-    void load(const char *fname,NSRLBloom &b);
-    void print_report(class xml *);
+    void load(const char *fname,NSRLBloom &b, uint32_t blocksize);
+    void print_report(class xml *, uint32_t blocksize);
 };
 
-void masterfile::print_report(class xml *x) {
+void masterfile::print_report(class xml *x, uint32_t blocksize) {
     printf("Master Block(s)     Found at image block\n");
     for(uint64_t tb=0;tb<(uint64_t)filemap.size();){
 	if (filemap[tb].size()==0){
@@ -358,7 +358,7 @@ void masterfile::add_block_hash(uint32_t blocknumber,const md5_t &md5,NSRLBloom 
     b.add(md5.digest);
 }
 
-void masterfile::load(const char *fname,NSRLBloom &b)
+void masterfile::load(const char *fname,NSRLBloom &b, uint32_t blocksize)
 {
     if(this->open(fname,blocksize)<0){
 	err(1,"Error: Cannot open %s",fname);
@@ -397,8 +397,8 @@ public:;
     masters_t():reg("([0-9a-f]{32})  (.*) offset ([0-9]+)-([0-9]+)",0){};
     NSRLBloom b;			  // bloom prefilter
     void bloom_create(int opt_M);	  // initialize the bloom filter
-    void add_master_file(const char *fn); // piecewise hash a file
-    void read_md5deep(const char *fn);	// read a set of files
+    void add_master_file(const char *fn, uint32_t blocksize); // piecewise hash a file
+    void read_md5deep(const char *fn, uint32_t blocksize);	// read a set of files
 };
 
 
@@ -412,11 +412,11 @@ void masters_t::bloom_create(int opt_M)
     printf("Bloom filter created.\n");
 }
 
-void masters_t::add_master_file(const char *fn)
+void masters_t::add_master_file(const char *fn, uint32_t blocksize)
 {
     printf("Adding Master File: %s (file #%zd)\n",fn,this->size()+1);
     masterfile *t = new masterfile();
-    t->load(fn,b);
+    t->load(fn,b,blocksize);
     this->push_back(t);
 }
 
@@ -440,7 +440,7 @@ int masters_t::md5deep_parse(string line,string *md5hex,string *fname,int64_t *s
     return 0;
 }
 
-void masters_t::read_md5deep(const char *fn)
+void masters_t::read_md5deep(const char *fn, uint32_t blocksize)
 {
     ifstream f(fn);
     if(!f.is_open()){
@@ -510,6 +510,7 @@ int main(int argc,char **argv)
     uint64_t bloom_false_positives=0;
     class xml *x = 0;
     string command_line;
+    uint32_t blocksize = DEFAULT_BLOCKSIZE;
 
     /* Make a copy of the command line */
     for(int i=0;i<argc;i++){
@@ -527,7 +528,7 @@ int main(int argc,char **argv)
 	case 'b': blocksize = atoi(optarg); break;
 	case 'S': opt_stats++;break;
 	case 'M': opt_M     = atoi(optarg); break;
-	case 'm': masters.read_md5deep(optarg); break;
+	case 'm': masters.read_md5deep(optarg,blocksize); break;//TODO: properly get blocksize
 	case 'X':
 	    switch(atoi(optarg)){
 	    case 1: use_bloom = 0;break;
@@ -577,7 +578,7 @@ int main(int argc,char **argv)
 
     /* Load up all of the master files */
     for(;*argv;argv++){
-	masters.add_master_file(*argv);
+	masters.add_master_file(*argv,blocksize);
     }
 
     printf("Now searching image file...\n");
@@ -706,13 +707,13 @@ int main(int argc,char **argv)
 	    printf("RAW FILEMAP:\n");
 	    printf("===============================================================================\n");
 	    printf("\n");
-	    (*t)->print_report(0);
+	    (*t)->print_report(0,blocksize);
 	}
 
 	(*t)->filemap.clean();
 
 	/* note: perhaps it would make more sense to iteratively clean. */
-	(*t)->print_report(x);
+	(*t)->print_report(x,blocksize);
 	printf("Total blocks of original file found: %"PRId64" (%2.0f%%)\n",
 	       (*t)->filemap.found_count(),
 	       (*t)->filemap.found_percent());


### PR DESCRIPTION
# Make `blocksize` a local variable
## The bug

In the main file `src/frag_find.cpp`, the block size is currently handled as a global variable:

``` c++
uint32_t blocksize = DEFAULT_BLOCKSIZE;
```

This introduces a bug always reproducible with the standard build `./bootstrap.sh && ./configure && make all`.
### Status

Working on:
- Darwin 12.3 x86_64 (Mac OS 10.8) with g++ 4.2.1
- Linux 3.2 x86_64 (Ubuntu 12.04) with g++ 4.6.3
### Description

Using any block size but 512 bytes leads to inconsistent results
### How to reproduce

Using block size 512:
- Scan something containing a blank block (512 consecutive zero bytes) for a master file (of any size at least the block size) full of zeros.
- Expected/actual behavior: the block size is 512; the blank block is detected.

Using any block size between 4 and 511:
- Scan the same thing containing a blank block (512 consecutive zero bytes) for a master file (of any size at least the block size) full of zeros.
- Expected behavior: at least a blank block is detected.
- Actual behavior: the target (the scanned image file) gets the proper block size, but the master file and the reports get blocksize 512 no matter what; nothing is detected even when the master file is larger than 512 bytes.
## The fix

I fixed it in the brutal simple way: make `blocksize` a local variable everywhere.
### Status

`uint32_t blocksize` is no longer declared in the global scope. Instead, it is now declared in `main()`, and set to `DEFAULT_BLOCKSIZE` like before. After that, it may be set in the option-parsing process like before.

Finally, it has been included as a parameter in all the function signatures where it was needed, all directly or undirectly called from `main()`.
### Side-effects

`blocksize` is actually needed in `read_md5deep`, which used to get called during the option-parsing process. To avoid inconsistencies that could occur if option `-m` was used before option `-b`, an intermediate local variable is now used for `-m` during the option-parsing process.
